### PR TITLE
Accommodate whitespace in header value

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Check HSTS on all of a site's possible IP addresses
 ```
 https-checker$ pipenv install
 https-checker$ pipenv run python -m unittest discover -s test
-https-checker$ pipenv run python the-most-american-web-site.gov
+https-checker$ pipenv run python https_checker.py the-most-american-web-site.gov
 ```
 
 The `package-lambda` shell script will build a ZIP file suitable for upload to AWS Lambda.

--- a/https_checker.py
+++ b/https_checker.py
@@ -78,8 +78,14 @@ def has_hsts(site, ip_string, is_ipv6=False):
   return all_responses_good
 
 def check_response_hsts(ip_string, response):
+  is_sts_header_valid = False
+
   sts_header = response.headers.get('strict-transport-security')
-  if sts_header == 'max-age=31536000; includeSubDomains; preload':
+  if sts_header:
+    sts_header_tokens = set([t.strip() for t in sts_header.split(';')])
+    is_sts_header_valid = (sts_header_tokens == set(['max-age=31536000', 'includeSubDomains', 'preload']))
+
+  if is_sts_header_valid:
     print("%s(%s) appears to have correct HSTS!" %
           (response.url, ip_string,))
     return True

--- a/https_checker.py
+++ b/https_checker.py
@@ -74,7 +74,7 @@ def has_hsts(site, ip_string, is_ipv6=False):
     for resp in response.history:
       all_responses_good &= check_response_hsts(ip_string, resp)
   # Either way check the final redirect landing point.
-  all_responses_good = check_response_hsts(ip_string, response)
+  all_responses_good &= check_response_hsts(ip_string, response)
   return all_responses_good
 
 def check_response_hsts(ip_string, response):

--- a/package_lambda
+++ b/package_lambda
@@ -5,6 +5,6 @@ OUTPUT_ABSOLUTE=${PWD}/https_checker_lambda_${TIMESTAMP}.zip
 
 VENV=$(pipenv --venv)
 pushd ${VENV}/lib/python3.7/site-packages
-zip -r9 ${OUTPUT_ABSOLUTE} ./* -x "./test/*" "./package_lambda"
+zip -r9 ${OUTPUT_ABSOLUTE} ./*
 popd
 zip -r9 ${OUTPUT_ABSOLUTE} *.py

--- a/package_lambda
+++ b/package_lambda
@@ -5,6 +5,6 @@ OUTPUT_ABSOLUTE=${PWD}/https_checker_lambda_${TIMESTAMP}.zip
 
 VENV=$(pipenv --venv)
 pushd ${VENV}/lib/python3.7/site-packages
-zip -r9 ${OUTPUT_ABSOLUTE} ./*
+zip -r9 ${OUTPUT_ABSOLUTE} ./* -x "./test/*" "./package_lambda"
 popd
 zip -r9 ${OUTPUT_ABSOLUTE} *.py


### PR DESCRIPTION
## Summary of changes

A few changes that made sense to me (but may be incorrect):
- accommodate whitespace in the header value (eg accept `includeSubDomains ;`)  (why: it's not unheard of to have extra whitespace - 2 examples: domains whitehouse.gov and dhs.gov )
- change a `=` to a `&=` (logic bug?) 
- reduce files included in the archive 
- edit sample usage code snippet